### PR TITLE
Support .h5 files

### DIFF
--- a/mmu-to-hats/catalog_functions/utils.py
+++ b/mmu-to-hats/catalog_functions/utils.py
@@ -52,7 +52,8 @@ class BaseTransformer(ABC):
         """Transform HDF5 file to PyArrow table."""
         if self._check_if_directory(hdf5_file_path):
             # list all files in the dir
-            hdf5_file_path = list(UPath(hdf5_file_path).glob("*.hdf5"))
+            suffixes = {".h5", ".hdf5"}
+            hdf5_file_path = sorted(p for p in UPath(hdf5_file_path).glob("*.h*5") if p.suffix in suffixes)
         if isinstance(hdf5_file_path, (str, Path, UPath)):
             return self.transform_from_hdf5_file(hdf5_file_path)
         elif isinstance(hdf5_file_path, list):

--- a/mmu-to-hats/main.py
+++ b/mmu-to-hats/main.py
@@ -161,7 +161,8 @@ class MMUReader(InputReader):
 
 
 def input_file_list(path: UPath) -> list[str]:
-    path_list = sorted(path.rglob("*.hdf5"))
+    suffixes = {".h5", ".hdf5"}
+    path_list = sorted(p for p in path.rglob("*.h*5") if p.suffix in suffixes)
     return [upath.path for upath in path_list]
 
 


### PR DESCRIPTION
Some datasets, for example vipers, use *.h5 file names, instead of *.hdf5. This adds the support of "h5" file extension