### PR TITLE
upgrade to datasets>=4.0 (For #8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pyarrow",
     "universal_pathlib",
     "click",
-    "datasets",
+    "datasets>=4.0",
 ]
 
 # add dev dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -881,7 +881,7 @@ dev = [
 requires-dist = [
     { name = "click" },
     { name = "dask", extras = ["distributed", "diagnostics"] },
-    { name = "datasets" },
+    { name = "datasets", specifier = ">=4.0" },
     { name = "h5py" },
     { name = "hats-import" },
     { name = "huggingface-hub" },

--- a/verification/process_btsbot_using_datasets.py
+++ b/verification/process_btsbot_using_datasets.py
@@ -1,4 +1,4 @@
-# NOTE: use datasets==3.6 for this
+# Process BTSBot dataset using the datasets library
 # Run this first
 # uv pip install -r requirements.txt
 # ./download_btsbot.sh
@@ -7,7 +7,7 @@ from mmu.utils import get_catalog
 from astropy.table import vstack
 
 # Load the dataset descriptions from local copy of the data
-desi = load_dataset_builder("data/MultimodalUniverse/v1/btsbot", trust_remote_code=True)
+desi = load_dataset_builder("data/MultimodalUniverse/v1/btsbot")
 desi.download_and_prepare()
 
 train_catalog = get_catalog(desi, split="train")

--- a/verification/process_desi_using_datasets.py
+++ b/verification/process_desi_using_datasets.py
@@ -1,4 +1,4 @@
-# NOTE: use datasets==3.6 for this
+# Process DESI dataset using the datasets library
 # Run this first
 # uv pip install -r requirements.txt
 # ./download_desi_hsc.sh
@@ -6,7 +6,7 @@ from datasets import load_dataset_builder, concatenate_datasets
 from mmu.utils import get_catalog
 
 # Load the dataset descriptions from local copy of the data
-desi = load_dataset_builder("data/MultimodalUniverse/v1/desi", trust_remote_code=True)
+desi = load_dataset_builder("data/MultimodalUniverse/v1/desi")
 desi.download_and_prepare()
 
 desi_catalog = get_catalog(desi)

--- a/verification/process_gaia_using_datasets.py
+++ b/verification/process_gaia_using_datasets.py
@@ -1,9 +1,9 @@
-# NOTE: run with datasets==3.6
+# Process Gaia dataset using the datasets library
 # uv run --with-requirements=verification/requirements.in python verification/process_gaia_using_datasets.py
 from datasets import load_dataset_builder
 
 # Load the dataset descriptions from local copy of the data
-gaia = load_dataset_builder("data/MultimodalUniverse/v1/gaia", trust_remote_code=True)
+gaia = load_dataset_builder("data/MultimodalUniverse/v1/gaia")
 gaia.download_and_prepare()
 
 # Gaia HDF5 files already contain ra, dec, healpix - no catalog join needed (unlike other datasets)

--- a/verification/process_sdss_using_datasets.py
+++ b/verification/process_sdss_using_datasets.py
@@ -1,4 +1,4 @@
-# NOTE: use datasets==3.6 for this
+# Process SDSS dataset using the datasets library
 # Run this first
 # uv pip install -r requirements.txt
 # ./download_sdss_hsc.sh
@@ -6,7 +6,7 @@ from datasets import load_dataset_builder, concatenate_datasets
 from mmu.utils import get_catalog
 
 # Load the dataset descriptions from local copy of the data
-sdss = load_dataset_builder("data/MultimodalUniverse/v1/sdss", trust_remote_code=True)
+sdss = load_dataset_builder("data/MultimodalUniverse/v1/sdss")
 sdss.download_and_prepare()
 
 sdss_catalog = get_catalog(sdss)

--- a/verification/process_tess_using_datasets.py
+++ b/verification/process_tess_using_datasets.py
@@ -1,4 +1,4 @@
-# NOTE: use datasets==3.6 for this
+# Process TESS dataset using the datasets library
 # Run this first
 # uv pip install -r requirements.txt
 # ./download_tess_hsc.sh
@@ -6,7 +6,7 @@ from datasets import load_dataset_builder, concatenate_datasets
 from mmu.utils import get_catalog
 
 # Load the dataset descriptions from local copy of the data
-tess = load_dataset_builder("data/MultimodalUniverse/v1/tess", trust_remote_code=True)
+tess = load_dataset_builder("data/MultimodalUniverse/v1/tess")
 tess.download_and_prepare()
 
 tess_catalog = get_catalog(tess, keys=["object_id", "RA", "DEC"])

--- a/verification/process_vipers_using_datasets.py
+++ b/verification/process_vipers_using_datasets.py
@@ -1,4 +1,4 @@
-# NOTE: use datasets==3.6 for this
+# Process VIPERS dataset using the datasets library
 # Run this first
 # uv pip install -r requirements.txt
 # ./download_sdss_hsc.sh
@@ -6,7 +6,7 @@ from datasets import load_dataset_builder, concatenate_datasets
 from mmu.utils import get_catalog
 
 # Load the dataset descriptions from local copy of the data
-sdss = load_dataset_builder("data/MultimodalUniverse/v1/vipers", trust_remote_code=True)
+sdss = load_dataset_builder("data/MultimodalUniverse/v1/vipers")
 sdss.download_and_prepare()
 
 sdss_catalog = get_catalog(sdss)

--- a/verification/requirements.in
+++ b/verification/requirements.in
@@ -1,4 +1,4 @@
-datasets==3.6
+datasets>=4.0
 git+https://github.com/MultimodalUniverse/MultimodalUniverse.git
 astropy==7.1
 scipy


### PR DESCRIPTION
Update all verification scripts and dependencies to use latest Hugging Face datasets library (v4.x). Removes deprecated `trust_remote_code` parameter from load_dataset_builder() calls.

Changed files:
- pyproject.toml: datasets -> datasets>=4.0
- verification/requirements.in: datasets==3.6 -> datasets>=4.0
- verification/process_*.py: removed trust_remote_code=True

CAVEATS:
- Requires local clone of MultimodalUniverse repo (already in requirements.in)
- Unit tests pass but integration tests with actual MMU data not verified
- If upstream MMU dataset loaders are incompatible with datasets 4.x, errors may surface at runtime when processing datasets