### PR TITLE
Fix byte-swapped array error for big-endian HDF5 files (e.g. JWST)

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,12 +179,16 @@ class MMUReader(InputReader):
                 if set([col.lower() for col in read_columns]) == set(["ra", "dec"]):
                     if cols_scalar[first_col_name]:
                         data = {
-                            col: np_to_pyarrow_array(np.array([h5_file[self._get_h5_column(h5_file, col)][()]]))
+                            col: np_to_pyarrow_array(
+                                np.array([h5_file[self._get_h5_column(h5_file, col)][()]]).astype(np.float64)
+                            )
                             for col in read_columns
                         }
                     else:
                         data = {
-                            col: np_to_pyarrow_array(h5_file[self._get_h5_column(h5_file, col)][i : i + chunk_size])
+                            col: np_to_pyarrow_array(
+                                h5_file[self._get_h5_column(h5_file, col)][i : i + chunk_size].astype(np.float64)
+                            )
                             for col in read_columns
                         }
                     table = pa.table(data)


### PR DESCRIPTION
The MMUReader.read() fast path for coordinate-only reads passes raw HDF5 array slices directly to np_to_pyarrow_array(), bypassing the transformer's dataset_to_table() which normalizes byte order via .astype() calls. HDF5 files stored in big-endian byte order (common in astronomy) cause PyArrow to raise ArrowNotImplementedError: "Byte-swapped arrays not supported".

Add .astype(np.float64) to the coordinate-only branch so that ra/dec arrays are converted to native byte order before being passed to PyArrow, matching what the transformers already do.